### PR TITLE
[Forwardport] Added alias to block 'product.info.description'

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -130,7 +130,7 @@
                 </block>
             </container>
             <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.details" template="Magento_Catalog::product/view/details.phtml" after="product.info.media">
-                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
+                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" as="description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
                     <arguments>
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14011
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Fixes bug where https://github.com/chedaroo/magento2/blob/05ac0d1915b4170a50dfa4ceb597fac3d74f1b23/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml#L25 uses alias html attributes.

Problem is as there is no **alias** on this block it's falling back to the block **name** instead which contains `.`

This is leading to elements with invalid html attribute values, specifically ID's.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Go to product view page and scroll down to 'product.info.details' block (Bottom tabs)
Inspect in devtools
Element which had id `'tab-label-product.info.description'` now has `'tab-label-description'`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
