### PR TITLE
[Forwardport] Disable "Back" button on the first step of the setup

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element.phtml
@@ -46,9 +46,6 @@
         <input type="<?= /* @escapeNotVerified */ $element->getType() ?>" name="<?= /* @escapeNotVerified */ $element->getName() ?>" id="<?= $element->getHtmlId() ?>" value="<?= /* @escapeNotVerified */ $element->getValue() ?>" class="input-text <?= /* @escapeNotVerified */ $element->getClass() ?>" title="<?= /* @escapeNotVerified */ $element->getTitle() ?>"/>
     </span>
       <?php break;
-    case 'hidden': ?>
-        <input type="<?= /* @escapeNotVerified */ $element->getType() ?>" name="<?= /* @escapeNotVerified */ $element->getName() ?>" id="<?= $element->getHtmlId() ?>" value="<?= /* @escapeNotVerified */ $element->getValue() ?>">
-      <?php break;
     case 'radios': ?>
     <span class="form_row">
         <label for="<?= $element->getHtmlId() ?>"><?= /* @escapeNotVerified */ $element->getLabel() ?>:</label>

--- a/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
@@ -146,6 +146,7 @@ class ImageBuilder
                 'custom_attributes' => $this->getCustomAttributes(),
                 'resized_image_width' => $imagesize[0],
                 'resized_image_height' => $imagesize[1],
+                'product_id' => $this->product->getId()
             ],
         ];
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -252,6 +252,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
                     'custom_attributes' => '',
                     'resized_image_width' => 100,
                     'resized_image_height' => 100,
+                    'product_id' => null
                 ],
             ],
         ];
@@ -286,6 +287,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
                     'custom_attributes' => 'name_1="value_1" name_2="value_2"',
                     'resized_image_width' => 120,
                     'resized_image_height' => 70,
+                    'product_id' => null
                 ],
             ],
         ];

--- a/app/code/Magento/Customer/Controller/Account/Index.php
+++ b/app/code/Magento/Customer/Controller/Account/Index.php
@@ -35,9 +35,6 @@ class Index extends \Magento\Customer\Controller\AbstractAccount
      */
     public function execute()
     {
-        /** @var \Magento\Framework\View\Result\Page $resultPage */
-        $resultPage = $this->resultPageFactory->create();
-        $resultPage->getConfig()->getTitle()->set(__('My Account'));
-        return $resultPage;
+        return $this->resultPageFactory->create();
     }
 }

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -6,6 +6,9 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Customer My Account (All Pages)" design_abstraction="custom">
+    <head>
+        <title>My Account</title>
+    </head>
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="sidebar.main">

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Sales.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Sales.php
@@ -56,9 +56,6 @@ abstract class Sales extends AbstractReport
             case 'coupons':
                 return $this->_authorization->isAllowed('Magento_Reports::coupons');
                 break;
-            case 'shipping':
-                return $this->_authorization->isAllowed('Magento_Reports::shipping');
-                break;
             case 'bestsellers':
                 return $this->_authorization->isAllowed('Magento_Reports::bestsellers');
                 break;

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -71,7 +71,6 @@ class Factory
      */
     protected $_backendOptions = [
         'hashed_directory_level' => 1,
-        'hashed_directory_umask' => 0777,
         'file_name_prefix' => 'mage',
     ];
 

--- a/setup/pub/magento/setup/main.js
+++ b/setup/pub/magento/setup/main.js
@@ -93,10 +93,6 @@ main.controller('navigationController',
             return str.indexOf(suffix, str.length - suffix.length) !== -1;
         };
 
-        $scope.goToStart = function() {
-            $scope.goToAction($state.current.type);
-        };
-
         $scope.goToBackup = function() {
             $state.go('root.create-backup-uninstall');
         };

--- a/setup/view/magento/setup/readiness-check.phtml
+++ b/setup/view/magento/setup/readiness-check.phtml
@@ -18,7 +18,7 @@
             <button
                 type="button"
                 class="btn"
-                ng-click="goToStart()"
+                disabled="disabled"
                 >Back</button>
         </div>
         <div class="btn-wrap btn-wrap-try-again"


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14309
### Description
When you enter the setup of Magento, the "Back" button is enabled
on the first step. When you click this, you go straight to the
final step of the installation, without entering any data in the
steps, so you can't install Magento at all.

With this commit the back button on the first step of the setup
is always disabled, since there's no previous step, except for the
page where you agree with the terms and conditions, which is not
part of the wizard.

### Fixed Issues
1. magento/magento2#14307: Possible to press the "Previous" button while in the first step of the installation

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a fresh Magento 2 environment
2. Go to the setup wizard in your browser
3. When on the first step, try to use the "Back" button. This is now disabled with this fix.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
