### PR TITLE
[Forwardport] Removed extra backslash from comment block

### DIFF
--- a/app/code/Magento/InstantPurchase/CustomerData/InstantPurchase.php
+++ b/app/code/Magento/InstantPurchase/CustomerData/InstantPurchase.php
@@ -30,7 +30,7 @@ class InstantPurchase implements SectionSourceInterface
     private $customerSession;
 
     /**
-     * @var StoreManagerInterface\
+     * @var StoreManagerInterface
      */
     private $storeManager;
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14440
Removed extra backslash(*&#92;*) from class name inside the comment block above the private member variable. It should say `StoreManagerInterface` instead of `StoreManagerInterface\`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
