### PR TITLE
[Forwardport] [Bug] Correctly construct Magento\Framework\Phrase

### DIFF
--- a/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
@@ -100,7 +100,7 @@ class Render extends AbstractAction
         } catch (\Exception $e) {
             $this->logger->critical($e);
             $result = [
-                'error' => _('UI component could not be rendered because of system exception'),
+                'error' => __('UI component could not be rendered because of system exception'),
                 'errorcode' => $this->escaper->escapeHtml($e->getCode())
             ];
             /** @var \Magento\Framework\Controller\Result\Json $resultJson */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/12951
There appears to be a typo in this action.

### Description

The `Magento\Ui\Controller\Adminhtml\Index\Render` action incorrectly calls `_` instead of `__`. This resulted in an error when I was running unit tests. I've searched the codebase for other instances of `_()` but did not find any.

### Fixed Issues (if relevant)

No issue.

### Manual testing scenarios

I was not able to manually trigger this error. We spotted the error during our CI build:

```
Magento\Ui\Test\Unit\Controller\Adminhtml\Index\RenderTest::testExecuteAjaxRequestException
Error: Call to undefined function Magento\Ui\Controller\Adminhtml\Index\_()

/var/www/magento/vendor/magento/module-ui/Controller/Adminhtml/Index/Render.php:91
/var/www/magento/vendor/magento/module-ui/Controller/Adminhtml/AbstractAction.php:62
/var/www/magento/vendor/magento/module-ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php:226
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
