### PR TITLE
[Forwardport] Fixed comparison with 0 bug for TableRate shipping carrier

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
@@ -99,7 +99,7 @@ class RateQuery
             }
         } else {
             $bind[':condition_name'] = $this->request->getConditionName();
-            $bind[':condition_value'] = $this->request->getData($this->request->getConditionName());
+            $bind[':condition_value'] = round($this->request->getData($this->request->getConditionName()), 4);
         }
 
         return $bind;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13831
### Description
In free shipping flow sometimes you can get such query to DB:
```sql
SQL: SELECT `shipping_tablerate`.* FROM `shipping_tablerate` WHERE ...
BIND: array (
':website_id' => 1,
':country_id' => 'US',
':region_id' => 12,
':postcode' => '68138',
':condition_name' => 'package_value',
':condition_value' => -3.5527136788005009E-15,
)
AFF: 0
```
It leads to disabled TabelRate shipping method. Such value is calculated in `Magento\OfflineShipping\Model\Carrier\Tablerate::collectRates().` Smth like:
```
29.95 - 10 - 19 - .95 = -3.5527136788005009E-15
```
and normally should be rounded before comparison. See http://php.net/manual/en/language.types.float.php

### Manual testing scenarios
1. Setup free shipping rule with Subtotal >= 25.
2. Setup TableRate shippign method.
3. Add products to cart.
4. Apply free shipping coupon.
5. TableRate shippign method disappears.
